### PR TITLE
Converted no.fintlabs:fint-model-resource into API dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {''
 
     implementation 'org.jetbrains:annotations:23.0.0'
 
-    implementation 'no.fintlabs:fint-model-resource:0.5.0'
+    api 'no.fintlabs:fint-model-resource:0.5.0'
 
     //compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
Converted dependency no.fintlabs:fint-model-resource from "implementation" to "api", thus making it part of the API of this library